### PR TITLE
Don't use absolute path for variable 'actionplugindevdir'

### DIFF
--- a/plugins/actions/changeframerate/Makefile.am
+++ b/plugins/actions/changeframerate/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = changeframerate
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/clipboard/Makefile.am
+++ b/plugins/actions/clipboard/Makefile.am
@@ -5,9 +5,7 @@ plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src \
-	$(SUBTITLEEDITOR_CFLAGS) \
-	-DSE_PLUGIN_PATH_DEV=\"$(actionplugindevdir)\" \
-	-DSE_PLUGIN_PATH_UI=\"$(uidir)\"
+	$(SUBTITLEEDITOR_CFLAGS)
 
 
 pluginlib_LTLIBRARIES = \

--- a/plugins/actions/configurekeyboardshortcuts/Makefile.am
+++ b/plugins/actions/configurekeyboardshortcuts/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = configurekeyboardshortcuts
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/dialoguize/Makefile.am
+++ b/plugins/actions/dialoguize/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = dialoguize
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/errorchecking/Makefile.am
+++ b/plugins/actions/errorchecking/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = errorchecking
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/externalvideoplayer/Makefile.am
+++ b/plugins/actions/externalvideoplayer/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = externalvideoplayer
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/findandreplace/Makefile.am
+++ b/plugins/actions/findandreplace/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = findandreplace
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/movesubtitles/Makefile.am
+++ b/plugins/actions/movesubtitles/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = movesubtitles
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/preferences/Makefile.am
+++ b/plugins/actions/preferences/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = preferences
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/scalesubtitles/Makefile.am
+++ b/plugins/actions/scalesubtitles/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = scalesubtitles
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/spellchecking/Makefile.am
+++ b/plugins/actions/spellchecking/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = spellchecking
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/splitdocument/Makefile.am
+++ b/plugins/actions/splitdocument/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = splitdocument
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/styleeditor/Makefile.am
+++ b/plugins/actions/styleeditor/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = styleeditor
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = $(srcdir)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/template/Makefile.am
+++ b/plugins/actions/template/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = template
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/textcorrection/Makefile.am
+++ b/plugins/actions/textcorrection/Makefile.am
@@ -2,7 +2,7 @@ plugin_name = textcorrection
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
 patterndir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/timingfromplayer/Makefile.am
+++ b/plugins/actions/timingfromplayer/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = timingfromplayer
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/actions/viewmanager/Makefile.am
+++ b/plugins/actions/viewmanager/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = viewmanager
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/actions
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/actions
-actionplugindevdir = $(abs_srcdir)
+actionplugindevdir = plugins/actions/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 AM_CPPFLAGS = \

--- a/plugins/subtitleformats/advancedsubstationalpha/Makefile.am
+++ b/plugins/subtitleformats/advancedsubstationalpha/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = advancedsubstationalpha
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/subtitleformats
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/subtitleformats
-subtitleformatplugindevdir = $(abs_srcdir)
+subtitleformatplugindevdir = plugins/subtitleformats/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 pluginlib_LTLIBRARIES = \

--- a/plugins/subtitleformats/avidds/Makefile.am
+++ b/plugins/subtitleformats/avidds/Makefile.am
@@ -1,8 +1,6 @@
 plugin_name = avidds
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/subtitleformats
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/subtitleformats
-subtitleformatplugindevdir = $(abs_srcdir)
-uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 pluginlib_LTLIBRARIES = \
 	libavidds.la
@@ -10,9 +8,7 @@ pluginlib_LTLIBRARIES = \
 libavidds_la_CXXFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src \
-	$(SUBTITLEEDITOR_CFLAGS) \
-	-DSE_PLUGIN_PATH_DEV=\"$(subtitleformatplugindevdir)\" \
-	-DSE_PLUGIN_PATH_UI=\"$(uidir)\"
+	$(SUBTITLEEDITOR_CFLAGS)
 
 libavidds_la_SOURCES = \
 	avidds.cc
@@ -25,8 +21,6 @@ plugindescription_DATA = $(plugindescription_in_files:.se-plugin.in=.se-plugin)
 
 @INTLTOOL_SE_PLUGIN_RULE@
 
-ui_DATA = 
-
-EXTRA_DIST = $(plugindescription_in_files) $(ui_DATA)
+EXTRA_DIST = $(plugindescription_in_files)
 
 CLEANFILES = $(plugindescription_DATA) Makefile.am~ *.cc~ *.h~ *.in~

--- a/plugins/subtitleformats/bitc/Makefile.am
+++ b/plugins/subtitleformats/bitc/Makefile.am
@@ -1,8 +1,6 @@
 plugin_name = bitc
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/subtitleformats
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/subtitleformats
-subtitleformatplugindevdir = $(abs_srcdir)
-uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 pluginlib_LTLIBRARIES = \
 	libbitc.la
@@ -10,9 +8,7 @@ pluginlib_LTLIBRARIES = \
 libbitc_la_CXXFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src \
-	$(SUBTITLEEDITOR_CFLAGS) \
-	-DSE_PLUGIN_PATH_DEV=\"$(subtitleformatplugindevdir)\" \
-	-DSE_PLUGIN_PATH_UI=\"$(uidir)\"
+	$(SUBTITLEEDITOR_CFLAGS)
 
 libbitc_la_SOURCES = \
 	bitc.cc
@@ -25,8 +21,6 @@ plugindescription_DATA = $(plugindescription_in_files:.se-plugin.in=.se-plugin)
 
 @INTLTOOL_SE_PLUGIN_RULE@
 
-ui_DATA = 
-
-EXTRA_DIST = $(plugindescription_in_files) $(ui_DATA)
+EXTRA_DIST = $(plugindescription_in_files)
 
 CLEANFILES = $(plugindescription_DATA) Makefile.am~ *.cc~ *.h~ *.in~

--- a/plugins/subtitleformats/substationalpha/Makefile.am
+++ b/plugins/subtitleformats/substationalpha/Makefile.am
@@ -1,7 +1,7 @@
 plugin_name = substationalpha
 pluginlibdir = $(PACKAGE_PLUGIN_LIB_DIR)/subtitleformats
 plugindescriptiondir = $(PACKAGE_PLUGIN_DESCRIPTION_DIR)/subtitleformats
-subtitleformatplugindevdir = $(abs_srcdir)
+subtitleformatplugindevdir = plugins/subtitleformats/$(plugin_name)
 uidir = $(PACKAGE_PLUGIN_SHARE_DIR)/$(plugin_name)
 
 pluginlib_LTLIBRARIES = \


### PR DESCRIPTION
Hi kitone,

In Debian we try to make our packages build [reproducibly](https://reproducible-builds.org/docs/definition/). This patch ensures that.

I made the path in SE_PLUGIN_PATH_DEV relative to the source root. This is the same behavior as for PACKAGE_UI_DIR_DEV. (Those variables play the same role in the code basically - they provide the directory of the .ui files)

Best,
Philip