### PR TITLE
Fix building with older version of enchant

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,10 +74,19 @@ AC_SUBST(GTKMM_LIBS)
 # =========================================================================
 # check enchant
 
-PKG_CHECK_MODULES(ENCHANT, enchant-2 >= 2.2.0)
+PKG_CHECK_MODULES(ENCHANT2, enchant-2 >= 2.2.0, have_enchant_2=yes, have_enchant_2=no)
 
-AC_SUBST(ENCHANT_CFLAGS)
-AC_SUBST(ENCHANT_LIBS)
+if test "x$have_enchant_2" = "xyes"; then
+	true  # make shell parser happy when AC_SUBST is replaced by void
+	AC_SUBST(ENCHANT2_CFLAGS)
+	AC_SUBST(ENCHANT2_LIBS)
+fi
+
+if test "x$have_enchant_2" = "xno"; then
+	PKG_CHECK_MODULES(ENCHANT, enchant >= 1.4.0)
+	AC_SUBST(ENCHANT_CFLAGS)
+	AC_SUBST(ENCHANT_LIBS)
+fi
 
 # =========================================================================
 # check libxml++


### PR DESCRIPTION
In debian, for example  enchant-2 is still in experimental repo.
It is better to be able to build both with enchant and enchant2

(Idea of the patch is taken from https://github.com/mate-desktop/pluma/commit/50a3efc)