### PR TITLE
Fix build with old version of enchant, take two

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,10 +74,17 @@ AC_SUBST(GTKMM_LIBS)
 # =========================================================================
 # check enchant
 
-PKG_CHECK_MODULES(ENCHANT, enchant-2 >= 2.2.0)
+PKG_CHECK_MODULES(ENCHANT2, enchant-2 >= 2.2.0, have_enchant_2=yes, have_enchant_2=no)
 
-AC_SUBST(ENCHANT_CFLAGS)
-AC_SUBST(ENCHANT_LIBS)
+if test "x$have_enchant_2" = "xyes"; then
+	ENCHANT_CFLAGS=$ENCHANT2_CFLAGS
+	ENCHANT_LIBS=$ENCHANT2_LIBS
+	AC_SUBST(ENCHANT_CFLAGS)
+	AC_SUBST(ENCHANT_LIBS)
+
+else
+	PKG_CHECK_MODULES(ENCHANT, enchant >= 1.4.0)
+fi
 
 # =========================================================================
 # check libxml++


### PR DESCRIPTION
enchant-2 is not wide spread enough, for example debian have it only in experemental repo now.
So it would be wise to make it possible to buld subtitleeditor with both enchant and echant-2